### PR TITLE
Update rubocop version

### DIFF
--- a/enabled.yml
+++ b/enabled.yml
@@ -869,7 +869,7 @@ Naming/UncommunicativeBlockParamName:
                 end in numbers, or do not meet a minimal length.
   Enabled: true
 
-Naming/UncommunicativeMethodArgName:
+Naming/UncommunicativeMethodParamName:
   Description: >-
                 Checks for method argument names that contain capital letters,
                 end in numbers, or do not meet a minimal length.

--- a/enabled.yml
+++ b/enabled.yml
@@ -1418,13 +1418,6 @@ Style/Dir:
                  absolute path to the current file.
   Enabled: true
 
-Style/Documentation:
-  Description: 'Document classes and non-namespace modules.'
-  Enabled: true
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: '#no-bang-bang'
@@ -1502,12 +1495,6 @@ Style/FormatString:
 
 Style/FormatStringToken:
   Description: 'Use a consistent style for format string tokens.'
-  Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Description: >-
-                 Add the frozen_string_literal comment to the top of files
-                 to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: true
 
 Style/GlobalVars:
@@ -1759,11 +1746,6 @@ Style/ParenthesesAroundCondition:
                  Don't use parentheses around the condition of an
                  if/unless/while.
   StyleGuide: '#no-parens-around-condition'
-  Enabled: true
-
-Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently'
-  StyleGuide: '#percent-literal-braces'
   Enabled: true
 
 Style/PercentQLiterals:

--- a/enabled.yml
+++ b/enabled.yml
@@ -78,6 +78,10 @@ Layout/AlignParameters:
   StyleGuide: '#no-double-indent'
   Enabled: true
 
+Layout/BlockAlignment:
+  Description: 'Align block ends correctly.'
+  Enabled: true
+
 Layout/BlockEndNewline:
   Description: 'Put end statement of multiline block on its own line.'
   Enabled: true
@@ -93,6 +97,17 @@ Layout/ClosingParenthesisIndentation:
 
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
+  Enabled: true
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: '#same-line-condition'
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Layout/DotPosition:
@@ -156,6 +171,10 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Description: "Keeps track of empty lines around module bodies."
   StyleGuide: '#empty-lines-around-bodies'
+  Enabled: true
+
+Layout/EndAlignment:
+  Description: 'Align ends correctly.'
   Enabled: true
 
 Layout/EndOfLine:
@@ -428,10 +447,6 @@ Lint/BigDecimalNew:
   Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
   Enabled: true
 
-Lint/BlockAlignment:
-  Description: 'Align block ends correctly.'
-  Enabled: true
-
 Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
@@ -440,19 +455,8 @@ Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
 
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: '#same-line-condition'
-  Enabled: true
-
 Lint/Debugger:
   Description: 'Check for debugger calls.'
-  Enabled: true
-
-Lint/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Lint/DeprecatedClassMethods:
@@ -494,10 +498,6 @@ Lint/EmptyInterpolation:
 
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
-  Enabled: true
-
-Lint/EndAlignment:
-  Description: 'Align ends correctly.'
   Enabled: true
 
 Lint/EndInMethod:
@@ -962,14 +962,6 @@ Performance/FlatMap:
   # `flatten` being called without any parameters.
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
-
-Performance/HashEachMethods:
-  Description: >-
-                 Use `Hash#each_key` and `Hash#each_value` instead of
-                 `Hash#keys.each` and `Hash#values.each`.
-  StyleGuide: '#hash-each'
-  Enabled: true
-  AutoCorrect: false
 
 Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -226,6 +226,19 @@ Layout/AlignParameters:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Layout/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+    - either
+    - start_of_block
+    - start_of_line
+
 # Indentation of `when`.
 Layout/CaseIndentation:
   EnforcedStyle: case
@@ -237,6 +250,17 @@ Layout/CaseIndentation:
   # But it can be overridden by setting this parameter.
   # This only matters if `IndentOneStep` is `true`
   IndentationWidth: ~
+
+Layout/DefEndAlignment:
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+    - start_of_line
+    - def
+  AutoCorrect: false
 
 # Multi-line method chaining should be done with leading dots.
 Layout/DotPosition:
@@ -274,6 +298,22 @@ Layout/EmptyLinesAroundModuleBody:
     - empty_lines_except_namespace
     - empty_lines_special
     - no_empty_lines
+
+# Align ends correctly.
+Layout/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (`if`, `while`, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+    - keyword
+    - variable
+    - start_of_line
+  AutoCorrect: false
 
 Layout/EndOfLine:
   # The `native` style means that CR+LF (Carriage Return + Line Feed) is
@@ -1487,46 +1527,6 @@ Metrics/PerceivedComplexity:
 # Allow safe assignment in conditions.
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
-
-# checks whether the end keywords are aligned properly for `do` `end` blocks.
-Lint/BlockAlignment:
-  # The value `start_of_block` means that the `end` should be aligned with line
-  # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole
-  # expression's starting line.
-  # The value `either` means both are allowed.
-  EnforcedStyleAlignWith: either
-  SupportedStylesAlignWith:
-    - either
-    - start_of_block
-    - start_of_line
-
-Lint/DefEndAlignment:
-  # The value `def` means that `end` should be aligned with the def keyword.
-  # The value `start_of_line` means that `end` should be aligned with method
-  # calls like `private`, `public`, etc, if present in front of the `def`
-  # keyword on the same line.
-  EnforcedStyleAlignWith: start_of_line
-  SupportedStylesAlignWith:
-    - start_of_line
-    - def
-  AutoCorrect: false
-
-# Align ends correctly.
-Lint/EndAlignment:
-  # The value `keyword` means that `end` should be aligned with the matching
-  # keyword (`if`, `while`, etc.).
-  # The value `variable` means that in assignments, `end` should be aligned
-  # with the start of the variable on the left hand side of `=`. In all other
-  # situations, `end` should still be aligned with the keyword.
-  # The value `start_of_line` means that `end` should be aligned with the start
-  # of the line which the matching keyword appears on.
-  EnforcedStyleAlignWith: keyword
-  SupportedStylesAlignWith:
-    - keyword
-    - variable
-    - start_of_line
-  AutoCorrect: false
 
 Lint/InheritException:
   # The default base class in favour of `Exception`.

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -738,7 +738,7 @@ Naming/UncommunicativeBlockParamName:
   # Blacklisted names that will register an offense
   ForbiddenNames: []
 
-Naming/UncommunicativeMethodArgName:
+Naming/UncommunicativeMethodParamName:
   # Argrument names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true


### PR DESCRIPTION
- [x] update rubocop version to 0.53
- [x] fix rubocop warnings:
   1. disabled cops in enabled.yml
   2. name of the cop


p.s. After this fix possible to use this configs in VS Code's extension
  
